### PR TITLE
Added verification before adding to the cart

### DIFF
--- a/scripts/modules/pages/productdetailpage/MProductDetailPage_clickAddToCart.xml
+++ b/scripts/modules/pages/productdetailpage/MProductDetailPage_clickAddToCart.xml
@@ -2,5 +2,8 @@
 <scriptmodule xmlns="http://xlt.xceptance.com/xlt-script/2" version="6">
   <description>Click add product to cart.</description>
   <command name="waitForElementPresent" target="id=add-to-cart"/>
+  <command name="assertNotClass" target="id=add-to-cart" value="add-to-cart-disabled">
+    <comment>Ensure that the add to cart button can be clicked, because it is active this means we check that the inactive class is not attached.</comment>
+  </command>
   <command name="click" target="id=add-to-cart"/>
 </scriptmodule>


### PR DESCRIPTION
Add verification to ensure that the add2cart button is really clickable and not deactivated via CSS. This will issue an error state earlier and therefore at the expected position. Otherwise a minicart action later would have failed without a reason.